### PR TITLE
chore: fix startup message according to CRAN email

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,19 +32,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
         env:
           NOT_CRAN: false
 

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
   promises
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/testthat/parallel: false

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,15 +1,15 @@
 .onAttach <- function(libname, pkgname) {
   # Check if necessary env variables have been set
   if(Sys.getenv("GCP_PROJECT") == "") {
-    cli::cli_alert_warning(
+    packageStartupMessage(cli::cli_alert_warning(
       "GCP_PROJECT environment not found, please set it up before starting!"
-    )
+    ))
   }
   
 
   if(Sys.getenv("GCP_AUTH_FILE") == "") {
-    cli::cli_alert_warning(
+    packageStartupMessage(cli::cli_alert_warning(
       "googlePubsubR: GCP_AUTH_FILE environment variable not found, please set it up before
-      authenticating")
+      authenticating"))
   }
 }


### PR DESCRIPTION
This fixes the following warning raised by CRAN

```
Result: NOTE
    ! GCP_PROJECT environment not found, please set it up before starting!
    ! googlePubsubR: GCP_AUTH_FILE environment variable not found, please set it up before
    authenticating
    
    It looks like this package (or a package it requires) has a startup
    message which cannot be suppressed: see ?packageStartupMessage.
Flavors: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/googlePubsubR-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/googlePubsubR-00check.html)
```





